### PR TITLE
added basic path storage in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
       "**/zod-to-json-schema",
       "**/zod-to-json-schema/**"
     ]
+  },
+  "dependencies": {
+    "nuqs": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
       "**/zod-to-json-schema",
       "**/zod-to-json-schema/**"
     ]
-  },
-  "dependencies": {
-    "nuqs": "^2.2.1"
   }
 }

--- a/packages/trpc-ui/package.json
+++ b/packages/trpc-ui/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "@textea/json-viewer": "^3.0.0",
     "fuzzysort": "^2.0.4",
+    "nuqs": "^2.2.1",
     "path": "^0.12.7",
     "pretty-bytes": "^6.1.0",
     "pretty-ms": "^8.0.0",

--- a/packages/trpc-ui/src/react-app/Root.tsx
+++ b/packages/trpc-ui/src/react-app/Root.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { RouterContainer } from "./components/RouterContainer";
 import type { ParsedRouter } from "../parse/parseRouter";
 import { RenderOptions } from "@src/render";
@@ -19,6 +19,10 @@ import { AllPathsContextProvider } from "@src/react-app/components/contexts/AllP
 import { HotKeysContextProvider } from "@src/react-app/components/contexts/HotKeysContext";
 import { SearchOverlay } from "@src/react-app/components/SearchInputOverlay";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useSiteNavigationContext } from "@src/react-app/components/contexts/SiteNavigationContext";
+import { NuqsAdapter } from 'nuqs/adapters/react'
+import { useQueryState } from 'nuqs'
+import { parseAsArrayOf, parseAsString } from 'nuqs'
 
 export function RootComponent({
   rootRouter,
@@ -30,21 +34,23 @@ export function RootComponent({
   trpc: ReturnType<typeof createTRPCReact>;
 }) {
   return (
-    <HeadersContextProvider>
-      <AllPathsContextProvider rootRouter={rootRouter}>
-        <SiteNavigationContextProvider>
-          <ClientProviders trpc={trpc} options={options}>
-            <HotKeysContextProvider>
-              <SearchOverlay>
-                <div className="flex flex-col w-full h-full flex-1 relative">
-                  <AppInnards rootRouter={rootRouter} />
-                </div>
-              </SearchOverlay>
-            </HotKeysContextProvider>
-          </ClientProviders>
-        </SiteNavigationContextProvider>
-      </AllPathsContextProvider>
-    </HeadersContextProvider>
+    <NuqsAdapter>
+      <HeadersContextProvider>
+        <AllPathsContextProvider rootRouter={rootRouter}>
+          <SiteNavigationContextProvider>
+            <ClientProviders trpc={trpc} options={options}>
+              <HotKeysContextProvider>
+                <SearchOverlay>
+                  <div className="flex flex-col w-full h-full flex-1 relative">
+                    <AppInnards rootRouter={rootRouter} />
+                  </div>
+                </SearchOverlay>
+              </HotKeysContextProvider>
+            </ClientProviders>
+          </SiteNavigationContextProvider>
+        </AllPathsContextProvider>
+      </HeadersContextProvider>
+    </NuqsAdapter>
   );
 }
 
@@ -89,6 +95,13 @@ function AppInnards({ rootRouter }: { rootRouter: ParsedRouter }) {
     "trpc-panel.show-minimap",
     true
   );
+  const { openAndNavigateTo } = useSiteNavigationContext();
+
+  const [path] = useQueryState("path", parseAsArrayOf(parseAsString, "."));
+
+  useEffect(() => {
+    openAndNavigateTo(path ?? [], true);
+  }, []);
 
   return (
     <div className="flex flex-col flex-1 relative">

--- a/packages/trpc-ui/src/react-app/components/CollapsableSection.tsx
+++ b/packages/trpc-ui/src/react-app/components/CollapsableSection.tsx
@@ -73,8 +73,7 @@ export function CollapsableSection({
       {collapsable ? (
         <button
           onClick={() => {
-            collapsables.toggle(fullPath)
-            console.log(fullPath);
+            collapsables.toggle(fullPath);
             setPath(fullPath.join("."));
           }}
           className="flex flex-row justify-between items-center p-1 "

--- a/packages/trpc-ui/src/react-app/components/CollapsableSection.tsx
+++ b/packages/trpc-ui/src/react-app/components/CollapsableSection.tsx
@@ -10,6 +10,8 @@ import {
   solidColorBg,
   solidColorBorder,
 } from "@src/react-app/components/style-utils";
+import { useQueryState } from 'nuqs'
+
 
 export type ColorSchemeType =
   | "query"
@@ -34,6 +36,8 @@ export function CollapsableSection({
 }) {
   const { scrollToPathIfMatches } = useSiteNavigationContext();
   const shown = useCollapsableIsShowing(fullPath);
+  const [_path, setPath] = useQueryState("path");
+
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -68,7 +72,11 @@ export function CollapsableSection({
     >
       {collapsable ? (
         <button
-          onClick={() => collapsables.toggle(fullPath)}
+          onClick={() => {
+            collapsables.toggle(fullPath)
+            console.log(fullPath);
+            setPath(fullPath.join("."));
+          }}
           className="flex flex-row justify-between items-center p-1 "
         >
           <span className="flex flex-row">

--- a/packages/trpc-ui/src/react-app/components/contexts/SiteNavigationContext.tsx
+++ b/packages/trpc-ui/src/react-app/components/contexts/SiteNavigationContext.tsx
@@ -115,6 +115,7 @@ export function SiteNavigationContextProvider({
     ) {
       return false;
     }
+
     scrollToPathRef.current = null;
     element.scrollIntoView({
       behavior: "smooth",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9786,6 +9786,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitt@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: b55a489ac9c2949ab166b7f060601d3b6d893a852515ae9eca4e11df01c013876df777ea109317622b5c1c60e8aae252558e33c8c94e14124db38f64a39614b1
+  languageName: node
+  linkType: hard
+
 "mixin-deep@npm:^1.2.0":
   version: 1.3.2
   resolution: "mixin-deep@npm:1.3.2"
@@ -10178,6 +10185,27 @@ __metadata:
   version: 1.0.1
   resolution: "number-is-nan@npm:1.0.1"
   checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
+  languageName: node
+  linkType: hard
+
+"nuqs@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "nuqs@npm:2.2.1"
+  dependencies:
+    mitt: ^3.0.1
+  peerDependencies:
+    "@remix-run/react": ">=2"
+    next: ">=14.2.0"
+    react: ">=18.2.0 || ^19.0.0-0"
+    react-router-dom: ">=6"
+  peerDependenciesMeta:
+    "@remix-run/react":
+      optional: true
+    next:
+      optional: true
+    react-router-dom:
+      optional: true
+  checksum: 6b878deb35745f2e20e64049698ddb706b3176209a3d2f95d726713d6f913b32ac1afef30b2e6416037715363842314c38528656c68ed538a52dd917b7045332
   languageName: node
   linkType: hard
 
@@ -13628,6 +13656,7 @@ __metadata:
   dependencies:
     "@nrwl/nx-cloud": latest
     "@tsconfig/docusaurus": ^1.0.6
+    nuqs: ^2.2.1
     nx: 15.2.4
     prettier: ^2.6.2
     typescript: ^4.9.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -13656,7 +13656,6 @@ __metadata:
   dependencies:
     "@nrwl/nx-cloud": latest
     "@tsconfig/docusaurus": ^1.0.6
-    nuqs: ^2.2.1
     nx: 15.2.4
     prettier: ^2.6.2
     typescript: ^4.9.3
@@ -13706,6 +13705,7 @@ __metadata:
     jest: ^29.3.1
     json-bigint: ^1.0.0
     jsoneditor: ^9.10.3
+    nuqs: ^2.2.1
     path: ^0.12.7
     postcss: ^8.4.19
     pretty-bytes: ^6.1.0


### PR DESCRIPTION
closes #23 

Used nuqs basic [react spa adapter](https://nuqs.47ng.com/docs/adapters#react-spa) to add a path query param. When collapsing or expanding a page it updates this query param, and on initial load it scrolls to the path from the query param.