### PR TITLE
Display responses correctly depending on if router uses superjson

### DIFF
--- a/packages/trpc-ui/src/react-app/Root.tsx
+++ b/packages/trpc-ui/src/react-app/Root.tsx
@@ -42,7 +42,7 @@ export function RootComponent({
               <HotKeysContextProvider>
                 <SearchOverlay>
                   <div className="flex flex-col w-full h-full flex-1 relative">
-                    <AppInnards rootRouter={rootRouter} />
+                    <AppInnards rootRouter={rootRouter} options={options}/>
                   </div>
                 </SearchOverlay>
               </HotKeysContextProvider>
@@ -90,7 +90,7 @@ function ClientProviders({
   );
 }
 
-function AppInnards({ rootRouter }: { rootRouter: ParsedRouter }) {
+function AppInnards({ rootRouter, options }: { rootRouter: ParsedRouter, options: RenderOptions }) {
   const [sidebarOpen, setSidebarOpen] = useLocalStorage(
     "trpc-panel.show-minimap",
     true
@@ -119,7 +119,7 @@ function AppInnards({ rootRouter }: { rootRouter: ParsedRouter }) {
           }}
         >
           <div className="container max-w-6xl p-4 pt-8">
-            <RouterContainer router={rootRouter} />
+            <RouterContainer router={rootRouter}  options={options}/>
           </div>
         </div>
       </div>

--- a/packages/trpc-ui/src/react-app/components/RouterContainer.tsx
+++ b/packages/trpc-ui/src/react-app/components/RouterContainer.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import { CollapsableSection } from "@src/react-app/components/CollapsableSection";
 import { ProcedureForm } from "@src/react-app/components/form/ProcedureForm";
 import { ParsedRouter } from "../../parse/parseRouter";
+import { RenderOptions } from "@src/render";
 
 export function RouterContainer({
   router,
+  options,
   name,
 }: {
   router: ParsedRouter;
+  options: RenderOptions;
   name?: string;
 }) {
   const isRoot = router.path.length == 0;
@@ -36,12 +39,14 @@ export function RouterContainer({
                 {routerOrProcedure.nodeType == "router" ? (
                   <RouterContainer
                     name={childName}
+                    options={options}
                     router={routerOrProcedure}
                   />
                 ) : (
                   <ProcedureForm
                     name={childName}
                     procedure={routerOrProcedure}
+                    options={options}
                   />
                 )}
               </div>

--- a/packages/trpc-ui/src/react-app/components/form/ProcedureForm/index.tsx
+++ b/packages/trpc-ui/src/react-app/components/form/ProcedureForm/index.tsx
@@ -21,6 +21,7 @@ import { Field } from "@src/react-app/components/form/Field";
 import { ProcedureFormContextProvider } from "@src/react-app/components/form/ProcedureForm/ProcedureFormContext";
 import getSize from "string-byte-length";
 import JSONEditor from "../JSONEditor";
+import { RenderOptions } from "@src/render";
 
 const TRPCErrorSchema = z.object({
   meta: z.object({
@@ -55,9 +56,11 @@ export const ROOT_VALS_PROPERTY_NAME = "vals";
 
 export function ProcedureForm({
   procedure,
+  options,
   name,
 }: {
   procedure: ParsedProcedure;
+  options: RenderOptions;
   name: string;
 }) {
   // null => request was never sent
@@ -158,12 +161,21 @@ export function ProcedureForm({
     setQueryEnabled(false);
   }
 
-  const data =
-    procedure.procedureType === "query"
-      ? query.data?.json ?? null
-      : mutationResponse;
+  let data: any; 
+  if (procedure.procedureType === "query") {
+    data = query.data ?? null;
+    if (options.transformer === "superjson" && data) {
+      data = data.json;
+    } 
+  }
+  else {
+    data = mutationResponse;
+    if (options.transformer === "superjson" && data) {
+      data = data.json;
+    }
+  }
   const error =
-    procedure.procedureType == "query" ? query.error : mutation.error;
+    procedure.procedureType === "query" ? query.error : mutation.error;
 
   // Fixes the timing for queries, not ideal but works
   useEffect(() => {


### PR DESCRIPTION
Closes #26 

Superjson parses response values under the `json` key. 

![Screenshot 2024-12-06 at 11 47 32 PM](https://github.com/user-attachments/assets/e018f4d1-b8c8-4afa-ac61-4da8cf641631)

This led to error when not using superjson, and mutation responses were not being displayed without the json key.

Now, both mutation and query responses will display correctly based on if the user specifies if they are using the superjson transformer or not.