### PR TITLE
Fixed non-superjson not being parsed correctly

### DIFF
--- a/packages/dev-app/.env.example
+++ b/packages/dev-app/.env.example
@@ -1,14 +1,2 @@
-# Since the ".env" file is gitignored, you can use the ".env.example" file to
-# build a new ".env" file when you clone the repo. Keep this file up-to-date
-# when you add new variables to `.env`.
-
-# This file will be committed to version control, so make sure not to have any
-# secrets in it. If you are cloning this repo, create a copy of this file named
-# ".env" and populate it with your secrets.
-
-# When adding additional environment variables, the schema in "/src/env.mjs"
-# should be updated accordingly.
-
-# Example:
-# SERVERVAR="foo"
-# NEXT_PUBLIC_CLIENTVAR="bar"
+# Set this value to "false" to test trpc-ui without the superjson data transformer
+NEXT_PUBLIC_SUPERJSON="true"

--- a/packages/dev-app/README.md
+++ b/packages/dev-app/README.md
@@ -1,3 +1,6 @@
 # Dev App
 
 This app is for development of `trpc-panel`. See our [contributing](../../CONTRIBUTING.md) guide for more information.
+
+## Toggling Superjson
+There are several features of `trpc-ui` which only work with superjson enabled, meaning it is important be able to quickly test the package with and without superjson. Superjson is enabled by default in the dev app, but can be disabled by setting an environment variable `SUPERJSON=false`

--- a/packages/dev-app/src/env.mjs
+++ b/packages/dev-app/src/env.mjs
@@ -6,6 +6,7 @@ import { z } from "zod";
  */
 const server = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]),
+  NEXT_PUBLIC_SUPERJSON: z.enum(["true", "false"])
 });
 
 /**
@@ -13,7 +14,7 @@ const server = z.object({
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 const client = z.object({
-  // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+  NEXT_PUBLIC_SUPERJSON: z.enum(["true", "false"])
 });
 
 /**
@@ -24,7 +25,7 @@ const client = z.object({
  */
 const processEnv = {
   NODE_ENV: process.env.NODE_ENV,
-  // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
+  NEXT_PUBLIC_SUPERJSON: process.env.NEXT_PUBLIC_SUPERJSON,
 };
 
 // Don't touch the part below

--- a/packages/dev-app/src/pages/index.tsx
+++ b/packages/dev-app/src/pages/index.tsx
@@ -3,8 +3,11 @@ import { parseRouterWithOptions } from "trpc-ui/parse/parseRouter";
 import { RootComponent } from "trpc-ui/react-app/Root";
 import { trpc } from "trpc-ui/react-app/trpc";
 import { appRouter } from "~/router";
+import { env } from "~/env.mjs";
 
-const parse = parseRouterWithOptions(appRouter, { transformer: "superjson" });
+
+console.log(`Using superjson: ${env.NEXT_PUBLIC_SUPERJSON}`)
+const parse = parseRouterWithOptions(appRouter, { transformer: env.NEXT_PUBLIC_SUPERJSON === "false" ? undefined : "superjson" });
 
 const App = dynamic(
   Promise.resolve(() => (
@@ -12,7 +15,7 @@ const App = dynamic(
       rootRouter={parse}
       options={{
         url: "http://localhost:3000/api/trpc",
-        transformer: "superjson",
+        transformer: env.NEXT_PUBLIC_SUPERJSON === "false" ? undefined : "superjson",
         meta: {
           title: "Dev App Title",
           description:

--- a/packages/dev-app/src/server/api/trpc.ts
+++ b/packages/dev-app/src/server/api/trpc.ts
@@ -54,12 +54,13 @@ import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import type { TRPCPanelMeta } from "trpc-ui";
 import { ZodError } from "zod";
+import { env } from "~/env.mjs";
 
 const t = initTRPC
   .context<typeof createTRPCContext>()
   .meta<TRPCPanelMeta>()
   .create({
-    transformer: superjson,
+    transformer: env.NEXT_PUBLIC_SUPERJSON === "false" ? undefined : superjson,
     errorFormatter({ shape, error }) {
       return {
         ...shape,

--- a/packages/trpc-ui/src/react-app/components/form/ProcedureForm/index.tsx
+++ b/packages/trpc-ui/src/react-app/components/form/ProcedureForm/index.tsx
@@ -129,7 +129,13 @@ export function ProcedureForm({
     },
   });
   function onSubmit(data: { [ROOT_VALS_PROPERTY_NAME]: any }) {
-    const newData = { json: data[ROOT_VALS_PROPERTY_NAME] };
+    let newData: any;
+    if (options.transformer === "superjson") {
+      newData = { json: data[ROOT_VALS_PROPERTY_NAME] };
+    }
+    else {
+      newData = { ...data[ROOT_VALS_PROPERTY_NAME] }
+    }
     if (procedure.procedureType === "query") {
       setQueryInput(newData);
       setQueryEnabled(true);


### PR DESCRIPTION
closes #27 

The main fix is here

```ts
if (options.transformer === "superjson") {
	newData = { json: data[ROOT_VALS_PROPERTY_NAME] };
}
else {
	newData = { ...data[ROOT_VALS_PROPERTY_NAME] }
}
```

in `packages/trpc-ui/src/react-app/components/form/ProcedureForm/index.tsx`

Previously it always included the json key. I'm not sure how this wasn't an issue brought up in the old package as I am pretty sure it also should have been broken there.