### PR TITLE
Add Support for File Upload with octetInputParser

### DIFF
--- a/packages/dev-app/src/router.ts
+++ b/packages/dev-app/src/router.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { octetInputParser } from "@trpc/server/http";
 import { z } from "zod";
 import { createTRPCRouter, procedure } from "~/server/api/trpc";
 
@@ -289,6 +290,18 @@ export const appRouter = createTRPCRouter({
       }),
     )
     .query(() => ({ goodJob: "yougotthedata" })),
+  uploadFile: procedure.input(octetInputParser)
+    .mutation(async ({ input }) => {
+      const reader = input.getReader();
+      let text = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (value) text += new TextDecoder().decode(value);
+        if (done) {
+          return text;
+        }
+      }
+    })
 });
 
 // export type definition of API

--- a/packages/trpc-ui/src/parse/parseNodeTypes.ts
+++ b/packages/trpc-ui/src/parse/parseNodeTypes.ts
@@ -54,6 +54,8 @@ export type NumberNode = { type: "number" } & SharedInputNodeProperties;
 
 export type BooleanNode = { type: "boolean" } & SharedInputNodeProperties;
 
+export type FileNode = { type: "file" } & SharedInputNodeProperties;
+
 export type UnsupportedNode = {
   type: "unsupported";
 } & SharedInputNodeProperties;
@@ -68,7 +70,8 @@ export type ParsedInputNode =
   | StringNode
   | NumberNode
   | BooleanNode
-  | UnsupportedNode;
+  | UnsupportedNode
+  | FileNode;
 
 export type AddDataFunctions = {
   addDescriptionIfExists: (

--- a/packages/trpc-ui/src/parse/parseProcedure.ts
+++ b/packages/trpc-ui/src/parse/parseProcedure.ts
@@ -18,6 +18,7 @@ import type {
 import { type AnyZodObject, z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { zodSelectorFunction } from "./input-mappers/zod/selector";
+import { octetInputParser } from "@trpc/server/http";
 
 export type ProcedureExtraData = {
   parameterDescriptions: { [path: string]: string };
@@ -75,6 +76,18 @@ function nodeAndInputSchemaFromInputs(
         addDataFunctions,
       }),
     };
+  }
+
+  if (inputs.length == 1 && inputs[0] == octetInputParser) {
+    const schema = z.instanceof(File);
+    return {
+      parseInputResult: "success",
+      schema: zodToJsonSchema(schema),
+      node: {
+        type: "file",
+        path: [],
+      }
+    }
   }
 
   let input = inputs[0];

--- a/packages/trpc-ui/src/react-app/Root.tsx
+++ b/packages/trpc-ui/src/react-app/Root.tsx
@@ -12,7 +12,7 @@ import { useLocalStorage } from "@src/react-app/components/hooks/useLocalStorage
 import type { RenderOptions } from "@src/render";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { type createTRPCReact, httpBatchLink } from "@trpc/react-query";
+import { type createTRPCReact, httpBatchLink, httpLink, isNonJsonSerializable, splitLink } from "@trpc/react-query";
 import { useQueryState } from "nuqs";
 import { parseAsArrayOf, parseAsString } from "nuqs";
 import { NuqsAdapter } from "nuqs/adapters/react";
@@ -71,9 +71,16 @@ function ClientProviders({
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [
-        httpBatchLink({
-          url: options.url,
-          headers: headers.getHeaders,
+        splitLink({
+          condition: (op) => isNonJsonSerializable(op.input),
+          true: httpLink({
+            url: options.url,
+            headers: headers.getHeaders,
+          }),
+          false: httpBatchLink({
+            url: options.url,
+            headers: headers.getHeaders,
+          }),
         }),
       ],
       transformer: (() => {

--- a/packages/trpc-ui/src/react-app/components/form/Field.tsx
+++ b/packages/trpc-ui/src/react-app/components/form/Field.tsx
@@ -11,6 +11,7 @@ import { NumberField } from "./fields/NumberField";
 import { ObjectField } from "./fields/ObjectField";
 import { TextField } from "./fields/TextField";
 import { UnionField } from "./fields/UnionField";
+import { FileField } from "./fields/FileField";
 
 export function Field({
   inputNode,
@@ -95,6 +96,13 @@ export function Field({
       );
     case "literal":
       return <LiteralField />;
+    case "file":
+      return <FileField
+          name={path}
+          label={label}
+          control={control}
+          node={inputNode}
+        />;
     case "unsupported":
       return null;
   }

--- a/packages/trpc-ui/src/react-app/components/form/fields/FileField.tsx
+++ b/packages/trpc-ui/src/react-app/components/form/fields/FileField.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import type { ParsedInputNode } from "@src/parse/parseNodeTypes";
+import { type Control, useController, useWatch } from "react-hook-form"
+import { FormLabel } from "../FormLabel";
+import { FieldError } from "./FieldError";
+
+export function FileField({
+  name,
+  label,
+  control,
+  node,
+}: {
+  name: string;
+  label: string;
+  control: Control<any>;
+  node: ParsedInputNode & { type: "file" };
+}) {
+  const { field, fieldState } = useController({
+    name,
+    control,
+  });
+  const fieldId = node.path.join(".");
+  const fileInput = useCallback((node: HTMLInputElement) => {
+    if (field.value instanceof File && node) {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(field.value);
+      node.files = dataTransfer.files;
+    }
+  }, [field.value]);
+
+  return <>
+    <FormLabel>{label}</FormLabel>
+    <input
+      ref={fileInput}
+      id={fieldId}
+      type="file"
+      onBlur={field.onBlur}
+      onChange={(e) => {
+        const file = e.target.files?.[0];
+        field.onChange(file)
+      }} />
+      {fieldState.error && <FieldError errorMessage={fieldState.error.message!}/>}
+  </>
+}


### PR DESCRIPTION
tRPC 11 support natively support uploading FIle (https://trpc.io/docs/server/non-json-content-types) using `octetInputParser `.  However when using this method, mutation can only upload 1 file and cannot add other key. Also, actually `octetInputParser` is not valid Zod schema. When we call `zodToJsonSchema` to mutation input with `octetInputParse`, this will cause error. Fotunately, `octetInputParser` is constant, when input definition is equal to `octetInputParser`, we can assume the mutation accept a file as input. Currently, client validation not work on file input.