### PR TITLE
add support for Markdown tables in description. add simple template options

### DIFF
--- a/packages/trpc-ui/README.md
+++ b/packages/trpc-ui/README.md
@@ -280,6 +280,7 @@ Some minor customizations to the UI template can be made with the `template` opt
       titleLink: "/",                           // default: https://github.com/aidansunbury/trpc-ui
       titleLinkOpensNewTab: false,              // default: true
       logoUrl: "https://example.com/logo.svg",  // default: <stock SVG>, max height is 40px
+      documentTitle: "Doc Title",               // default: <template.title> ?? tRPC.ui()
     },
   })
 ```

--- a/packages/trpc-ui/README.md
+++ b/packages/trpc-ui/README.md
@@ -268,6 +268,22 @@ Enter the json supported equivalent under the _json_ key, and and specify how th
 
 Also be warned that currently, input fields will not be rendered for superjson only inputs. You will have to input all data manually through the json editor.
 
+## UI Template
+
+Some minor customizations to the UI template can be made with the `template` option. All of these are optional.
+
+```ts
+  renderTrpcPanel(myTrpcRouter, {
+    url: "http://localhost:4000/trpc", // Base url of your trpc server
+    template: {
+      title: "Custom Title",                    // default: tRPC.ui()
+      titleLink: "/",                           // default: https://github.com/aidansunbury/trpc-ui
+      titleLinkOpensNewTab: false,              // default: true
+      logoUrl: "https://example.com/logo.svg",  // default: <stock SVG>, max height is 40px
+    },
+  })
+```
+
 ## Contributing
 
 `trpc-ui` welcomes and encourages open source contributions. Please see our [contributing](./CONTRIBUTING.md) guide for information on how to develop locally. Besides contributing PRs, one of the most helpful things you can to is to look at the existing [feature proposals](https://github.com/aidansunbury/trpc-ui/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3Aenhancement) and leave a 👍 on the features that would be most helpful for you.

--- a/packages/trpc-ui/package.json
+++ b/packages/trpc-ui/package.json
@@ -103,6 +103,7 @@
     "pretty-bytes": "^6.1.0",
     "pretty-ms": "^8.0.0",
     "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.1",
     "string-byte-length": "^1.6.0",
     "tailwind-merge": "^2.5.5",
     "url": "^0.11.0",

--- a/packages/trpc-ui/src/react-app/components/TopBar.tsx
+++ b/packages/trpc-ui/src/react-app/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { Chevron } from "@src/react-app/components/Chevron";
 import { LogoSvg } from "@src/react-app/components/LogoSvg";
 import { useHeadersContext } from "@src/react-app/components/contexts/HeadersContext";
 import { useSearch } from "@src/react-app/components/contexts/SearchStore";
+import { useRenderOptions } from "@src/react-app/components/contexts/OptionsContext";
 import { useIsMac } from "@src/react-app/components/hooks/useIsMac";
 import React from "react";
 
@@ -15,6 +16,8 @@ export function TopBar({
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const { setHeadersPopupShown } = useHeadersContext();
+  const { template } = useRenderOptions();
+  
   return (
     <div className="position-fixed top-0 right-0 left-0 flex h-16 w-full flex-row items-center justify-between border-b border-b-panelBorder bg-actuallyWhite bg-gray-50 px-4 pr-8 drop-shadow-sm">
       <div className="flex flex-row items-center gap-4">
@@ -31,13 +34,13 @@ export function TopBar({
           )}
         </button>
         <a
-          href="https://github.com/aidansunbury/trpc-ui"
-          target="_blank"
+          href={template?.titleLink ?? "https://github.com/aidansunbury/trpc-ui"}
+          target={template?.titleLinkOpensNewTab === false ? "_self" : "_blank"}
           className="flex flex-row items-center font-bold font-mono text-lg"
           rel="noreferrer"
         >
-          <LogoSvg className="mr-2 h-10 w-10 rounded-lg" />
-          tRPC.ui()
+          { template?.logoUrl ? <img src={template.logoUrl} style={{maxHeight: 40 }} /> : <LogoSvg className="mr-2 h-10 w-10 rounded-lg" /> }
+          { template?.title ?? "tRPC.ui()" }
         </a>
       </div>
       <RouterSearchTooltip />

--- a/packages/trpc-ui/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
+++ b/packages/trpc-ui/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
@@ -3,6 +3,8 @@ import { FormLabel } from "@src/react-app/components/form/FormLabel";
 import { FormSection } from "@src/react-app/components/form/ProcedureForm/FormSection";
 import React, { type ReactNode } from "react";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
 export function DocumentationSection({
   extraData,
 }: {
@@ -17,7 +19,7 @@ export function DocumentationSection({
         {extraData.description && (
           <DocumentationSubsection title="Description">
             <article className="prose">
-              <Markdown>{extraData.description}</Markdown>
+              <Markdown remarkPlugins={[remarkGfm]}>{extraData.description}</Markdown>
             </article>
           </DocumentationSubsection>
         )}

--- a/packages/trpc-ui/src/react-app/index.html
+++ b/packages/trpc-ui/src/react-app/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>tRPC.ui()</title>
+    <title>{{title}}</title>
     {{css}}
 </head>
 <body class="h-full">

--- a/packages/trpc-ui/src/render.ts
+++ b/packages/trpc-ui/src/render.ts
@@ -12,10 +12,18 @@ export type Info = {
   description?: string;
 };
 
+export type Template = {
+  title?: string;
+  titleLink?: string;
+  titleLinkOpensNewTab?: boolean;
+  logoUrl?: string;
+}
+
 export type RenderOptions = {
   url: string;
   cache?: boolean;
   meta?: Info;
+  template?: Template;
 } & TrpcPanelExtraOptions;
 
 const defaultParseRouterOptions: Partial<TrpcPanelExtraOptions> = {

--- a/packages/trpc-ui/src/render.ts
+++ b/packages/trpc-ui/src/render.ts
@@ -16,6 +16,7 @@ export type Template = {
   title?: string;
   titleLink?: string;
   titleLinkOpensNewTab?: boolean;
+  documentTitle?: string;
   logoUrl?: string;
 }
 
@@ -32,6 +33,7 @@ const defaultParseRouterOptions: Partial<TrpcPanelExtraOptions> = {
 };
 
 const dirLocation = dirname(fileURLToPath(import.meta.url));
+const titleReplaceSymbol = "{{title}}";
 const javascriptReplaceSymbol = "{{js}}";
 const cssReplaceSymbol = "{{css}}";
 const routerReplaceSymbol = '"{{parsed_router}}"';
@@ -98,6 +100,7 @@ export function renderTrpcPanel(router: AnyTRPCRouter, options: RenderOptions) {
   const bundleInjected = injectParams(bundleJs, bundleInjectionParams);
   const script = `<script>${bundleInjected}</script>`;
   const css = `<style>${indexCss}</style>`;
+  const { template } = options;
   const htmlReplaceParams: InjectionParam[] = [
     {
       searchFor: javascriptReplaceSymbol,
@@ -107,6 +110,10 @@ export function renderTrpcPanel(router: AnyTRPCRouter, options: RenderOptions) {
       searchFor: cssReplaceSymbol,
       injectString: css,
     },
+    {
+      searchFor: titleReplaceSymbol,
+      injectString: template?.documentTitle ?? template?.title ?? "tRPC.ui()",
+    }
   ];
   cache.val = injectParams(indexHtml, htmlReplaceParams);
   return cache.val;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 11.0.0-rc.446(@trpc/server@11.0.0-rc.446)
       '@trpc/next':
         specifier: ^11.0.0-next-beta.264
-        version: 11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/react-query@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/server@11.0.0-rc.446)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2))(@trpc/server@11.0.0-rc.446)(next@13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)
+        version: 11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/react-query@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/server@11.0.0-rc.446)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2))(@trpc/server@11.0.0-rc.446)(next@13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)
       '@trpc/react-query':
         specifier: ^11.0.0-next-beta.264
         version: 11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/server@11.0.0-rc.446)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)
@@ -40,7 +40,7 @@ importers:
         version: 10.4.20(postcss@8.4.49)
       next:
         specifier: ^13.2.4
-        version: 13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-transpile-modules:
         specifier: ^10.0.0
         version: 10.0.1
@@ -77,7 +77,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       react-scan:
         specifier: ^0.2.12
-        version: 0.2.12(@types/react@18.3.18)(next@13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.29.5)
+        version: 0.2.12(@types/react@18.3.18)(next@13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.29.5)
       typescript:
         specifier: ^5.4.5
         version: 5.7.2
@@ -140,7 +140,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       trpc-ui:
         specifier: latest
-        version: 1.0.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@mui/material@5.16.12(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@11.0.0-rc.446)(@types/react@18.3.18)(monaco-editor@0.52.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod@3.24.1)
+        version: 1.0.15(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@mui/material@5.16.12(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@11.0.0-rc.446)(@types/react@18.3.18)(monaco-editor@0.52.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod@3.24.1)
       tsconfig-paths:
         specifier: ^4.1.0
         version: 4.2.0
@@ -202,6 +202,9 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.3.18)(react@18.2.0)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       string-byte-length:
         specifier: ^1.6.0
         version: 1.6.0
@@ -2745,6 +2748,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3925,6 +3932,9 @@ packages:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   matchdep@2.0.0:
     resolution: {integrity: sha512-LFgVbaHIHMqCRuCZyfCtUOq9/Lnzhi7Z0KFUE2fhD54+JN2jLh3hC02RLkqauJ3U4soU6H1J3tfj/Byk7GoEjA==}
     engines: {node: '>= 0.10.0'}
@@ -3933,8 +3943,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -3983,6 +4014,27 @@ packages:
 
   micromark-core-commonmark@2.0.2:
     resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -5000,11 +5052,17 @@ packages:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.1:
     resolution: {integrity: sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   remove-bom-buffer@3.0.0:
     resolution: {integrity: sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==}
@@ -5624,8 +5682,8 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  trpc-ui@1.0.13:
-    resolution: {integrity: sha512-wLYgul79IUkZuUqTrIK3RRZVlYRBYmgGxiNAtG+pBhZgOZPqUtrVe49in/uiFrV5fMqwT1JLaKgw8HIdE2uMmA==}
+  trpc-ui@1.0.15:
+    resolution: {integrity: sha512-bM+cBeQgFFrDD1TNuvbsre+WXuLYbxsEoI6W4Zg402dqpMdeWD9NxEr/K4ZVaZGzbV+RAUqUZSlS4X8AMmbUpA==}
     peerDependencies:
       '@trpc/server': ^11.0.0-next-beta.264
       zod: ^3.19.1
@@ -7181,11 +7239,11 @@ snapshots:
     dependencies:
       '@trpc/server': 11.0.0-rc.446
 
-  '@trpc/next@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/react-query@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/server@11.0.0-rc.446)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2))(@trpc/server@11.0.0-rc.446)(next@13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)':
+  '@trpc/next@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/react-query@11.0.0-rc.666(@tanstack/react-query@5.62.10(react@18.2.0))(@trpc/client@11.0.0-rc.446(@trpc/server@11.0.0-rc.446))(@trpc/server@11.0.0-rc.446)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2))(@trpc/server@11.0.0-rc.446)(next@13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)':
     dependencies:
       '@trpc/client': 11.0.0-rc.446(@trpc/server@11.0.0-rc.446)
       '@trpc/server': 11.0.0-rc.446
-      next: 13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       typescript: 5.7.2
@@ -8672,6 +8730,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -10154,6 +10214,8 @@ snapshots:
     dependencies:
       object-visit: 1.0.1
 
+  markdown-table@3.0.4: {}
+
   matchdep@2.0.0:
     dependencies:
       findup-sync: 2.0.0
@@ -10164,6 +10226,13 @@ snapshots:
       - supports-color
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -10179,6 +10248,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.1
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10285,6 +10411,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.0.3
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.2
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.1
 
   micromark-factory-destination@2.0.1:
@@ -10533,7 +10717,7 @@ snapshots:
     dependencies:
       enhanced-resolve: 5.18.0
 
-  next@13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 13.5.8
       '@swc/helpers': 0.5.2
@@ -10542,7 +10726,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.26.0)(react@18.2.0)
       watchpack: 2.4.0
     optionalDependencies:
       '@next/swc-darwin-arm64': 13.5.8
@@ -11269,7 +11453,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-scan@0.2.12(@types/react@18.3.18)(next@13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.29.5):
+  react-scan@0.2.12(@types/react@18.3.18)(next@13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.29.5):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.3
@@ -11291,7 +11475,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       tsx: 4.19.2
     optionalDependencies:
-      next: 13.5.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 13.5.8(@babel/core@7.26.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       unplugin: 2.1.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11388,6 +11572,17 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -11404,6 +11599,12 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   remove-bom-buffer@3.0.0:
     dependencies:
@@ -11896,10 +12097,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.1(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.26.0)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.26.0
 
   stylehacks@5.1.1(postcss@8.4.49):
     dependencies:
@@ -12111,7 +12314,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  trpc-ui@1.0.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@mui/material@5.16.12(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@11.0.0-rc.446)(@types/react@18.3.18)(monaco-editor@0.52.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod@3.24.1):
+  trpc-ui@1.0.15(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@mui/material@5.16.12(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react@18.2.0))(@types/react@18.3.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@11.0.0-rc.446)(@types/react@18.3.18)(monaco-editor@0.52.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod@3.24.1):
     dependencies:
       '@monaco-editor/react': 4.7.0(monaco-editor@0.52.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@stoplight/json-schema-sampler': 0.3.0


### PR DESCRIPTION
I'd like to be able to add a Markdown table to descriptions and customize the header by using my own title, logo, url. 

